### PR TITLE
tf700t: re-enable DeviceKeyhandler so we have dock keyboard suppprt

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -151,12 +151,12 @@
     <bool name="config_lidControlsSleep">true</bool>
     <integer name="config_lidOpenRotation">0</integer>
     <integer name="config_lidKeyboardAccessibility">1</integer>
-<!--
+
     <string name="config_deviceKeyHandlerLib" translatable="false">
         /system/framework/org.omnirom.asusdec.jar</string>
     <string name="config_deviceKeyHandlerClass" translatable="false">
         org.omnirom.asusdec.KeyHandler</string>
--->
+
     <bool name="config_showNavigationBar">true</bool>
     <integer name="config_multiuserMaximumUsers">4</integer>
     <bool name="config_enableMultiUserUI">true</bool>


### PR DESCRIPTION
Since https://gerrit.omnirom.org/#/c/10823/ is committed we can use the devicekeyhandler class for the special dock keys.

Change-Id: I522e824ea100399a2922b2e769dc66ac5e9fc3c1